### PR TITLE
Simplify view dismissal

### DIFF
--- a/Gallery/Screens/Contacts/AddNewContact/NewContactView.swift
+++ b/Gallery/Screens/Contacts/AddNewContact/NewContactView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 
 struct NewContactView: View {
     @EnvironmentObject var galleryViewModel: GalleryViewModel
+    @Environment(\.dismiss) private var dismiss
     @State var newContact = Contact()
-    @Binding var newContactPresented: Bool
     
     var body: some View {
         VStack {
@@ -29,13 +29,13 @@ struct NewContactView: View {
             
             actionButton(buttonTitle: "Save Contact") {
                 galleryViewModel.addNewContactToGallery(with: newContact.name, organisation: newContact.organisation)
-                newContactPresented = false
+                dismiss()
             }
         }
     }
 }
 
 #Preview {
-    NewContactView(newContactPresented: .constant(false))
+    NewContactView()
 }
 

--- a/Gallery/Screens/Contacts/ContactsView.swift
+++ b/Gallery/Screens/Contacts/ContactsView.swift
@@ -25,14 +25,14 @@ struct ContactsView: View {
             .toolbar {
                 Button {
                     print("Add new Contact")
-                    viewModel.isShowingNewContactView = true
+                    viewModel.isShowingNewContactView.toggle()
                 } label: {
                     Image(systemName: "plus")
                 }
             }
         }
         .sheet(isPresented: $viewModel.isShowingNewContactView) {
-            NewContactView(newContactPresented: $viewModel.isShowingNewContactView)
+            NewContactView()
         }
     }
 }

--- a/Gallery/Screens/Home/AddNewItem/NewItemView.swift
+++ b/Gallery/Screens/Home/AddNewItem/NewItemView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct NewItemView: View {
     @EnvironmentObject var galleryViewModel: GalleryViewModel
+    @Environment(\.dismiss) private var dismiss
     @State var newItem = Item()
     @State var showTechniqueDialog = false
-    @Binding var newItemPresented: Bool
     
     var body: some View {
         VStack {
@@ -52,12 +52,9 @@ struct NewItemView: View {
             
             actionButton(buttonTitle: "Save Item") {
                 galleryViewModel.addNewItemToGallery(with: newItem.name, description: newItem.description)
-                newItemPresented = false
+                dismiss()
             }
         }
-//        let dimension: Dimension
-//        let imageName: String
-//        let dateCreated: Date
     }
 }
 
@@ -81,5 +78,5 @@ struct actionButton: View {
 }
 
 #Preview {
-    NewItemView(newItemPresented: .constant(false))
+    NewItemView()
 }

--- a/Gallery/Screens/Home/ItemsView.swift
+++ b/Gallery/Screens/Home/ItemsView.swift
@@ -81,7 +81,7 @@ struct ItemsView: View {
                     .toolbar {
                         Button {
                             print("Add new Item")
-                            viewModel.isShowingNewItemView = true
+                            viewModel.isShowingNewItemView.toggle()
                         } label: {
                             Image(systemName: "plus")
                         }
@@ -103,7 +103,7 @@ struct ItemsView: View {
             }
         }
         .sheet(isPresented: $viewModel.isShowingNewItemView) {
-            NewItemView(newItemPresented: $viewModel.isShowingNewItemView)
+            NewItemView()
         }
         .sheet(isPresented: $viewModel.isShowingItemDetailView) {
             ItemDetailsView(selectedItem: viewModel.selectedItem, isShowingItemDetailView: $viewModel.isShowingItemDetailView)

--- a/Gallery/Screens/Orders/AddNewOrder/NewOrderView.swift
+++ b/Gallery/Screens/Orders/AddNewOrder/NewOrderView.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 struct NewOrderView: View {
     @EnvironmentObject var galleryViewModel: GalleryViewModel
+    @Environment(\.dismiss) private var dismiss
     @State var beneficiaryName: String = ""
     @State var beneficiaryID: UUID?
-    @Binding var newOrderPresented: Bool
     @State private var selectedBeneficiary: Contact = Contact()
     
     var body: some View {
@@ -33,7 +33,7 @@ struct NewOrderView: View {
             }
             actionButton(buttonTitle: "Save Order") {
                 galleryViewModel.addNewOrderToGallery(with: selectedBeneficiary.id)
-                newOrderPresented = false
+                dismiss()
             }
         }
         .onAppear {
@@ -47,5 +47,5 @@ struct NewOrderView: View {
 }
 
 #Preview {
-    NewOrderView(newOrderPresented: .constant(true))
+    NewOrderView()
 }

--- a/Gallery/Screens/Orders/OrdersView.swift
+++ b/Gallery/Screens/Orders/OrdersView.swift
@@ -25,14 +25,14 @@ struct OrdersView: View {
             .toolbar {
                 Button {
                     print("Add new Order")
-                    viewModel.isShowingNewOrderView = true
+                    viewModel.isShowingNewOrderView.toggle()
                 } label: {
                     Image(systemName: "plus")
                 }
             }
         }
         .sheet(isPresented: $viewModel.isShowingNewOrderView) {
-            NewOrderView(newOrderPresented: $viewModel.isShowingNewOrderView)
+            NewOrderView()
         }
     }
 }

--- a/Gallery/Views/Cells/OrderListCell.swift
+++ b/Gallery/Views/Cells/OrderListCell.swift
@@ -14,10 +14,9 @@ struct OrderListCell: View {
     var body: some View {
         VStack {
             Text(galleryViewModel.beneficiaryName(for: order.beneficiary))
-                .font(.title)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            Text("\(order.items.count)")
-                .font(.title3)
+            Text("Items in order: \(order.items.count)")
+                .font(.caption)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         


### PR DESCRIPTION
- use the environment variable when dismissing a view instead of using a binding